### PR TITLE
bump ocamlfind version to 1.0.2 to match opam.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright 2008 Martin Jambon. All rights reserved.
 # This file is distributed under the terms stated in file LICENSE.
 
-VERSION = 1.0.1
+VERSION = 1.0.2
 export VERSION
 
 .PHONY: all install clean


### PR DESCRIPTION
v1.0.1 for ocaml < 4.0
v1.0.2 for ocaml >= 4.0 < 4.02

(have fixes for 4.02 as well, will wait to try and understand it a bit better first!)
